### PR TITLE
upgrade the site plugin to 3.7

### DIFF
--- a/demos/demo-maven-plugin/src/site/site.xml
+++ b/demos/demo-maven-plugin/src/site/site.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- http://maven.apache.org/plugins/maven-site-plugin/examples/sitedescriptor.html -->
 <project xmlns="http://maven.apache.org/DECORATION/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/DECORATION/1.1.0 http://maven.apache.org/xsd/decoration-1.1.0.xsd">
   <bannerLeft>
@@ -14,7 +15,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.0</version>
+    <version>1.5</version>
   </skin>
 
   <custom>
@@ -32,7 +33,7 @@
 
   <body>
     <head>
-      <link rel="stylesheet" href="@relativePath@/css/plain-links.css" />
+      <![CDATA[<link rel="stylesheet" href="@relativePath@/css/plain-links.css" />]]>
     </head>
     <breadcrumbs>
       <item name="Hello World" href="https://xiaojiac.github.io/hello-world/" />
@@ -45,7 +46,7 @@
       <item name="Sample:Docker Maven Plugin" href="asciidoc/docker-plugin-usage.html"/>
     </menu>
 
-    <menu ref="reports" inherit="top" />
+    <!--<menu ref="reports" inherit="top" />-->
   </body>
 
   <poweredBy>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -33,7 +33,7 @@
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
-    <maven-pmd-plugin.version>3.10.0</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
@@ -52,8 +52,8 @@
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <asciidoctor-maven-plugin.version>1.5.3</asciidoctor-maven-plugin.version>
     <maven-plugin-plugin.version>3.5.2</maven-plugin-plugin.version>
-    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
-    <maven-site-plugin.version>3.3</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
+    <maven-site-plugin.version>3.7</maven-site-plugin.version>
     <maven-surefire-report-plugin.version>2.21.0</maven-surefire-report-plugin.version>
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
@@ -205,6 +205,26 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${maven-pmd-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-java</artifactId>
+              <version>6.8.0</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-vm</artifactId>
+              <version>6.8.0</version>
+            </dependency>
+            <!-- https://github.com/alibaba/p3c -->
+            <!--
+            <dependency>
+              <groupId>com.alibaba.p3c</groupId>
+              <artifactId>p3c-pmd</artifactId>
+              <version>1.3.5</version>
+            </dependency>
+            -->
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -299,29 +319,12 @@
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven-site-plugin.version}</version>
         </plugin>
+        <!-- https://issues.apache.org/jira/projects/MPIR/issues/MPIR-374?filter=allopenissues -->
+        <!-- -Dorg.slf4j.simpleLogger.log.org.apache.maven.report.projectinfo.DependencyManagementReport=ERROR -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>${maven-project-info-reports-plugin.version}</version>
-          <dependencies>
-            <!-- Replace problematic bcel version. See https://issues.apache.org/jira/browse/MPIR-370 -->
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-shared-jar</artifactId>
-              <version>1.2</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>com.google.code.findbugs</groupId>
-                  <artifactId>bcel-findbugs</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.bcel</groupId>
-              <artifactId>bcel</artifactId>
-              <version>6.2</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,20 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <version>3.3</version>
+            <version>3.7</version>
             <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-site-renderer</artifactId>
+                <version>1.8.1</version>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-core</artifactId>
+                <version>1.8</version>
+              </dependency>
               <!-- http://khuxtable.github.io/wagon-gitsite/usage.html -->
               <!-- 另一种方式: https://myshittycode.com/2015/05/05/maven-deploying-generated-site-to-github/ -->
               <dependency>
@@ -118,7 +129,7 @@
               <dependency>
                 <groupId>org.apache.maven.doxia</groupId>
                 <artifactId>doxia-module-markdown</artifactId>
-                <version>1.4</version>
+                <version>1.7</version>
               </dependency>
               <!--
               <dependency>


### PR DESCRIPTION
当升级关联插件maven-project-info-reports-plugin到**3.0.0**时，发现未解决bug[MPIR-374](https://issues.apache.org/jira/projects/MPIR/issues/MPIR-374?filter=allopenissues)，因此待定